### PR TITLE
Use tolerances provided by Move Base Flex

### DIFF
--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -429,16 +429,16 @@ public:
   boost::mutex& configMutex() {return config_mutex_;}
 
   /**
-   * Get xy tolerance taking into account the values provided by mbf in isGoalReached
+   * Get xy tolerance taking into account the values provided by MBF in isGoalReached
    *
-   * @return Current xy tolerance
+   * @return XY tolerance
    */
   double getXYGoalTolerance() const;
 
   /**
-   * Get yaw tolerance taking into account the values provided by mbf in isGoalReached
+   * Get yaw tolerance taking into account the values provided by MBF in isGoalReached
    *
-   * @return Current yaw tolerance
+   * @return Yaw tolerance
    */
   double getYawGoalTolerance() const;
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -117,6 +117,8 @@ public:
   {
     double yaw_goal_tolerance; //!< Allowed final orientation error
     double xy_goal_tolerance; //!< Allowed final euclidean distance to the goal position
+    double mbf_yaw_goal_tolerance; //!< yaw_goal_tolerance provided by MBF in isGoalReached
+    double mbf_xy_goal_tolerance; //!< xy_goal_tolerance provided by MBF in isGoalReached
     bool free_goal_vel; //!< Allow the robot's velocity to be nonzero (usally max_vel) for planning purposes
     double trans_stopped_vel; //!< Below what maximum velocity we consider the robot to be stopped in translation
     double theta_stopped_vel; //!< Below what maximum rotation velocity we consider the robot to be stopped in rotation
@@ -292,6 +294,8 @@ public:
 
     goal_tolerance.xy_goal_tolerance = 0.2;
     goal_tolerance.yaw_goal_tolerance = 0.2;
+    goal_tolerance.mbf_xy_goal_tolerance = 0.0;
+    goal_tolerance.mbf_yaw_goal_tolerance = 0.0;
     goal_tolerance.free_goal_vel = false;
     goal_tolerance.trans_stopped_vel = 0.1;
     goal_tolerance.theta_stopped_vel = 0.1;
@@ -423,6 +427,20 @@ public:
    * @brief Return the internal config mutex
    */
   boost::mutex& configMutex() {return config_mutex_;}
+
+  /**
+   * Get xy tolerance taking into account the values provided by mbf in isGoalReached
+   *
+   * @return Current xy tolerance
+   */
+  double getXYGoalTolerance() const;
+
+  /**
+   * Get yaw tolerance taking into account the values provided by mbf in isGoalReached
+   *
+   * @return Current yaw tolerance
+   */
+  double getYawGoalTolerance() const;
 
 private:
   boost::mutex config_mutex_; //!< Mutex for config accesses and changes

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -166,9 +166,13 @@ public:
   bool isGoalReached();
 
   /**
-    * @brief Dummy version to satisfy MBF API
+    * @brief  Check if the goal pose has been achieved
+    * 
+    * The actual check is performed in computeVelocityCommands(). 
+    * Only the status flag is checked here.
+    * @return True if achieved, false otherwise
     */
-  bool isGoalReached(double xy_tolerance, double yaw_tolerance) { return isGoalReached(); };
+  bool isGoalReached(double xy_tolerance, double yaw_tolerance);
 
   /**
     * @brief Requests the planner to cancel, e.g. if it takes too much time

--- a/src/graph_search.cpp
+++ b/src/graph_search.cpp
@@ -99,7 +99,7 @@ void lrKeyPointGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, dou
   // Direction-vector between start and goal and normal-vector:
   Eigen::Vector2d diff = goal.position()-start.position();
 
-  if (diff.norm()<cfg_->goal_tolerance.xy_goal_tolerance)
+  if (diff.norm()<cfg_->getXYGoalTolerance())
   {
     ROS_DEBUG("HomotopyClassPlanner::createProbRoadmapGraph(): xy-goal-tolerance already reached.");
     if (hcp_->getTrajectoryContainer().empty())
@@ -227,7 +227,7 @@ void ProbRoadmapGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, do
   Eigen::Vector2d diff = goal.position()-start.position();
   double start_goal_dist = diff.norm();
 
-  if (start_goal_dist<cfg_->goal_tolerance.xy_goal_tolerance)
+  if (start_goal_dist<cfg_->getXYGoalTolerance())
   {
     ROS_DEBUG("HomotopyClassPlanner::createProbRoadmapGraph(): xy-goal-tolerance already reached.");
     if (hcp_->getTrajectoryContainer().empty())

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -393,5 +393,17 @@ void TebConfig::checkDeprecated(const ros::NodeHandle& nh) const
   if (nh.hasParam("global_plan_via_point_sep"))
     ROS_WARN("TebLocalPlannerROS() Param Warning: 'global_plan_via_point_sep' is deprecated. It has been replaced by 'global_plan_viapoint_sep' due to consistency reasons.");
 }
+
+double TebConfig::getXYGoalTolerance() const
+{
+  return goal_tolerance.mbf_xy_goal_tolerance > 0 ? goal_tolerance.mbf_xy_goal_tolerance :
+                                                    goal_tolerance.xy_goal_tolerance;
+}
+
+double TebConfig::getYawGoalTolerance() const
+{
+  return goal_tolerance.mbf_yaw_goal_tolerance > 0 ? goal_tolerance.mbf_yaw_goal_tolerance :
+                                                     goal_tolerance.yaw_goal_tolerance;
+}
     
 } // namespace teb_local_planner

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -478,20 +478,20 @@ bool TebLocalPlannerROS::isGoalReached(double xy_tolerance, double yaw_tolerance
 {
   boost::mutex::scoped_lock lock(cfg_.configMutex());
 
-  bool is_goal_reached = false;
+  // tolerances used to compute goal_reached_ in previous time step
+  const double prev_xy_goal_tolerance = cfg_.getXYGoalTolerance();
+  const double prev_yaw_goal_tolerance = cfg_.getYawGoalTolerance();
 
-  // goal_reached_ is computed in the previous time step
-  // so we can only trust its value if new tolerances are not stricter
-  if (xy_tolerance >= cfg_.goal_tolerance.mbf_xy_goal_tolerance &&
-      yaw_tolerance >= cfg_.goal_tolerance.mbf_yaw_goal_tolerance)
-  {
-    is_goal_reached = isGoalReached();
-  }
-
+  // update tolerances
   cfg_.goal_tolerance.mbf_xy_goal_tolerance = xy_tolerance;
   cfg_.goal_tolerance.mbf_yaw_goal_tolerance = yaw_tolerance;
 
-  return is_goal_reached;
+  // goal_reached_ is computed in the previous time step
+  // so we can only trust its value if new tolerances are not stricter
+  goal_reached_ &=
+      cfg_.getXYGoalTolerance() >= prev_xy_goal_tolerance && cfg_.getYawGoalTolerance() >= prev_yaw_goal_tolerance;
+
+  return isGoalReached();
 }
 
 

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -293,8 +293,8 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   double dx = global_goal.pose.position.x - robot_pose_.x();
   double dy = global_goal.pose.position.y - robot_pose_.y();
   double delta_orient = g2o::normalize_theta( tf2::getYaw(global_goal.pose.orientation) - robot_pose_.theta() );
-  if(fabs(std::sqrt(dx*dx+dy*dy)) < cfg_.goal_tolerance.xy_goal_tolerance
-    && fabs(delta_orient) < cfg_.goal_tolerance.yaw_goal_tolerance
+  if(fabs(std::sqrt(dx*dx+dy*dy)) < cfg_.getXYGoalTolerance()
+    && fabs(delta_orient) < cfg_.getYawGoalTolerance()
     && (!cfg_.goal_tolerance.complete_global_plan || via_points_.size() == 0)
     && (base_local_planner::stopped(base_odom, cfg_.goal_tolerance.theta_stopped_vel, cfg_.goal_tolerance.trans_stopped_vel)
         || cfg_.goal_tolerance.free_goal_vel))
@@ -473,6 +473,26 @@ bool TebLocalPlannerROS::isGoalReached()
   return false;
 }
 
+
+bool TebLocalPlannerROS::isGoalReached(double xy_tolerance, double yaw_tolerance)
+{
+  boost::mutex::scoped_lock lock(cfg_.configMutex());
+
+  bool is_goal_reached = false;
+
+  // goal_reached_ is computed in the previous time step
+  // so we can only trust its value if new tolerances are not stricter
+  if (xy_tolerance >= cfg_.goal_tolerance.mbf_xy_goal_tolerance &&
+      yaw_tolerance >= cfg_.goal_tolerance.mbf_yaw_goal_tolerance)
+  {
+    is_goal_reached = isGoalReached();
+  }
+
+  cfg_.goal_tolerance.mbf_xy_goal_tolerance = xy_tolerance;
+  cfg_.goal_tolerance.mbf_yaw_goal_tolerance = yaw_tolerance;
+
+  return is_goal_reached;
+}
 
 
 void TebLocalPlannerROS::updateObstacleContainerWithCostmap()


### PR DESCRIPTION
## Description

[Wrike Task](https://www.wrike.com/open.htm?id=1060721217)
Change TEB to use the tolerances provided by MBF when computing if the robot reached the goal.
This PR focuses on implementing the feature with minimal changes rather than ensuring absolute correctness (i.e. that would require quite a bit of refactoring to compute `goal_reached_` inside `isGoalReached` rather than `computeVelocityCommands`).

Do we want to make a PR upstream as well? It's a pretty big change in behavior since most of the time TEB will not be using the tolerances from dynamic reconfig but the ones from mbf. If we do want to make a PR upstream, then maybe add a parameter to toggle this feature?

## Demo

Notice how we instantly succeed navigation to every checkpoint when giving tolerance of 10m.
Without this PR the robot would move to every checkpoint since it would be using the tolerances from TEB instead.

https://user-images.githubusercontent.com/15384781/221458838-98f9f217-f363-464b-8ad5-9effa92b85b9.mp4