### PR TITLE
Return message when trajectory diversion error occurs

### DIFF
--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -382,6 +382,7 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
     ++no_infeasible_plans_; // increase number of infeasible solutions in a row
     time_last_infeasible_plan_ = ros::Time::now();
     last_cmd_ = cmd_vel.twist;
+    message = "teb_local_planner trajectory has diverged";
     return mbf_msgs::ExePathResult::NO_VALID_CMD;
   }
          


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=1099086391

All other `NO_VALID_CMD` errors have messages like:
 `message = "teb_local_planner trajectory is not feasible";`
 `message = "teb_local_planner velocity command invalid";`
 `message = "teb_local_planner steering angle is not finite";`
 `message = "teb_local_planner was not able to obtain a local plan";`
